### PR TITLE
remove 'b' parameter in creation of outstrm with output file

### DIFF
--- a/dslog2csv.py
+++ b/dslog2csv.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
     col = ['inputfile', ]
     col.extend(DSLogParser.OUTPUT_COLUMNS)
     if args.output:
-        outstrm = open(args.output, 'wb')
+        outstrm = open(args.output, 'w')
     else:
         outstrm = sys.stdout
     outcsv = csv.DictWriter(outstrm, fieldnames=col, extrasaction='ignore')


### PR DESCRIPTION
When using this, I found that I would get an error stating a bytes-like object is required, not 'str'. When I removed the 'b' parameter on line 182, I no longer received this error. I was getting the error on both Linux and Windows, and changing this parameter has removed the error on both platforms.