### PR TITLE
Remove reversal of PDP values

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,3 @@ Program: https://github.com/orangelight/DSLOG-Reader
 However, DSLog-Reader does not seem to be fully correct:
 * It unpacks the "packet loss" value as a *signed* integer. Unsigned gives more sensible answers (https://github.com/orangelight/DSLOG-Reader/issues/3)
 * There is a bug in FormMain::BoolNameToValue(): wrong string for "Robo Tele" and "Watchdog" returns the Brownout value. (https://github.com/orangelight/DSLOG-Reader/issues/2)
-* It does not reverse the PDP values, as indicated in the Chief Delphi post (but I don't have another reference).

--- a/dslogparser/dslogparser.py
+++ b/dslogparser/dslogparser.py
@@ -5,7 +5,6 @@
 
 # Notes on comparison to DSLog-Parse:
 # D-P has packet_loss as a *signed* integer, which makes no sense. Unsigned looks sensible.
-# D-P did not reverse the PDP values as was indicated in the CD post
 
 import datetime
 import math
@@ -154,10 +153,6 @@ class DSLogParser():
         vals = []
         for offset in pdp_offsets:
             vals.append(self.shifted_float(self.uint_from_bytes(pdp_bytes, offset, 10), 3))
-
-        # values are 15 through 0, so reverse the list
-        # note: DSLog-Reader did not reverse these. Don't know who to believe.
-        vals.reverse()
 
         total_i = 0.0
         for i in vals:


### PR DESCRIPTION
Comparison of the generated CSV file with the plots in the official DS Log File Viewer showed that the CSV file had the PDP values in reverse order. This PR removes the reversal of the PDP values so that they are in the correct order.
